### PR TITLE
fix invalid JSON error message when using any byAttribute methods.

### DIFF
--- a/lib/Janrain/Api/Capture/Entity.php
+++ b/lib/Janrain/Api/Capture/Entity.php
@@ -284,6 +284,7 @@ class Entity extends AbstractApi
 
 		return $this->post('entity.update', $params);
 	}
+
 	protected function wrapAttributeValueWithQuotes($attributeValue)
 	{
 		return '"' . $attributeValue . '"'; // String values need to be enclosed in quotes

--- a/lib/Janrain/Api/Capture/Entity.php
+++ b/lib/Janrain/Api/Capture/Entity.php
@@ -28,7 +28,7 @@ class Entity extends AbstractApi
 	public function viewByAttribute($attributeKey, $attributeValue, array $params)
 	{
 		$params['key_attribute'] = $attributeKey;
-		$params['key_value']     = "'{$attributeValue}'"; // String values need to be enclosed in quotes
+		$params['key_value']     = $this->wrapAttributeValueWithQuotes($attributeValue);
 
 		return $this->_view($params);
 	}
@@ -113,7 +113,7 @@ class Entity extends AbstractApi
 	public function deleteByAttribute($attributeKey, $attributeValue, array $params)
 	{
 		$params['key_attribute'] = $attributeKey;
-		$params['key_value']     = "'{$attributeValue}'"; // String values need to be enclosed in quotes
+		$params['key_value']     = $this->wrapAttributeValueWithQuotes($attributeValue);
 
 		return $this->_del($params);
 	}
@@ -207,7 +207,7 @@ class Entity extends AbstractApi
 	public function replaceByAttribute($attributeKey, $attributeValue, array $params)
 	{
 		$params['key_attribute'] = $attributeKey;
-		$params['key_value']     = "'{$attributeValue}'"; // String values need to be enclosed in quotes
+		$params['key_value']     = $this->wrapAttributeValueWithQuotes($attributeValue);
 
 		return $this->_replace($params);
 	}
@@ -259,7 +259,7 @@ class Entity extends AbstractApi
 	public function updateByAttribute($attributeKey, $attributeValue, array $params)
 	{
 		$params['key_attribute'] = $attributeKey;
-		$params['key_value']     = "'{$attributeValue}'"; // String values need to be enclosed in quotes
+		$params['key_value']     = $this->wrapAttributeValueWithQuotes($attributeValue);
 
 		return $this->_update($params);
 	}
@@ -283,5 +283,9 @@ class Entity extends AbstractApi
 		}
 
 		return $this->post('entity.update', $params);
+	}
+	protected function wrapAttributeValueWithQuotes($attributeValue)
+	{
+		return '"' . $attributeValue . '"'; // String values need to be enclosed in quotes
 	}
 }

--- a/test/Janrain/Tests/Api/Capture/EntityTest.php
+++ b/test/Janrain/Tests/Api/Capture/EntityTest.php
@@ -57,7 +57,7 @@ class EntityTest extends TestCase
 		$api = $this->getApiMock();
 		$api->expects($this->once())
 			->method('post')
-			->with('entity', array('key_attribute' => 'email', 'key_value' => "'user@example.com'", 'type_name' => 'user'))
+			->with('entity', array('key_attribute' => 'email', 'key_value' => '"user@example.com"', 'type_name' => 'user'))
 			->will($this->returnValue($expectedArray));
 
 		$this->assertEquals($expectedArray, $api->viewByAttribute('email', 'user@example.com', array('type_name' => 'user')));
@@ -272,7 +272,7 @@ class EntityTest extends TestCase
 		$api = $this->getApiMock();
 		$api->expects($this->once())
 			->method('post')
-			->with('entity.delete', array('key_attribute' => 'email', 'key_value' => "'user@example.com'", 'type_name' => 'user'))
+			->with('entity.delete', array('key_attribute' => 'email', 'key_value' => '"user@example.com"', 'type_name' => 'user'))
 			->will($this->returnValue($expectedArray));
 
 		$this->assertEquals($expectedArray, $api->deleteByAttribute('email', 'user@example.com', array('type_name' => 'user')));


### PR DESCRIPTION
I encountered an issue when using any of the `byAttribute` methods, in my case specifically the `viewByAttributeMethod`. 

The error from Janrain was:

`ValidationFailedException`

The error message from Janrain was:

```
Validation Failed: key_value was not valid for the following reason: the JSON is not syntactically valid
```

The API is expecting strings to be wrapped in `"` (double quotes).
